### PR TITLE
feat: Navigation Title 표출 지연 현상 해결 방법 추가

### DIFF
--- a/Sources/LinkNavigator/Components/WrappingController.swift
+++ b/Sources/LinkNavigator/Components/WrappingController.swift
@@ -18,7 +18,17 @@ public final class WrappingController<Content: View>: UIHostingController<Conten
   {
     self.matchPath = matchPath
     super.init(rootView: content())
-    title = matchPath
+    super.title = matchPath
+  }
+  
+  public init(
+    matchPath: String,
+    title: String? = .none,
+    @ViewBuilder content: () -> Content)
+  {
+    self.matchPath = matchPath
+    super.init(rootView: content())
+    super.title = title
   }
 
   required init?(coder _: NSCoder) {


### PR DESCRIPTION
## 이슈

안녕하세요. 🙂

`.next` 메서드를 통해 다음 View가 호출될 때, 아래와 같이 **`navigationTitle` 이 반박자 느리게 표시**되는 문제를 겪었습니다.
(Xcode 14.3, iOS 16.0 later)

![before](https://github.com/interactord/LinkNavigator/assets/13725729/2604f202-8776-403a-8261-3d392e463add)

위 화면은 SwiftUI의 `.navigationTitle()` modifier를 호출되는 View 내부에서 선언한 경우입니다.

```swift
struct InformationView: View {

  var body: some View {
    VStack {
      // some codes
    }
    .navigationTitle("이용 안내")
  }
}
```

## 수정

해결 방법을 찾아본 결과, `WrappingController` 의 생성자에서 만든  `UIHostingController` 객체에 직접 `.title` 속성을 지정해주는 방법으로 해결을 할 수 있었습니다.

> https://stackoverflow.com/questions/74247582/navigation-bar-title-appears-with-delay-in-mixed-uikit-and-swiftui-project
> 

- `WrappingController.swift`

```swift
public final class WrappingController<Content: View>: UIHostingController<Content>, MatchPathUsable {
  ...
  ...
  public init(  // ✅ Overloading
    matchPath: String,
    title: String,  // ✅
    @ViewBuilder content: () -> Content)
  {
    self.matchPath = matchPath
    super.init(rootView: content())
    super.title = title  // ✅
  }
}
```

- `~~~RouteBuilder.swift`  (예시 파일)

```swift
struct InformationRouteBuilder: RouteBuilder {
    var matchPath: String { "information" }
    
    var build: (LinkNavigatorType, [String : String], DependencyType) -> MatchingViewController? {
        { navigator, items, dependency in
            return WrappingController(
                matchPath: matchPath,
                title: "이용 안내")  // ✅
            {
                InformationView(navigator: navigator)
            }
        }
    }
}
```

위의 `WrappingController.swift` 에서, 오버로딩을 통해 새로 만든 생성자를 사용하면 아래와 같이 `navigationTitle`이 딜레이 없이 나타나는 것을 확인하였습니다.

![after](https://github.com/interactord/LinkNavigator/assets/13725729/978c6bc8-e823-4548-b4ef-069de78adb25)

확인 부탁드립니다. ^^