### PR TITLE
fix: 중복된 코드 제거

### DIFF
--- a/Sources/LinkNavigator/Deplecate/LinkNavigator.swift
+++ b/Sources/LinkNavigator/Deplecate/LinkNavigator.swift
@@ -90,8 +90,6 @@ extension LinkNavigator: LinkNavigatorType {
     }
 
     newSubNavigationController.setViewControllers(new, animated: false)
-
-    newSubNavigationController.setViewControllers(new, animated: false)
     newSubNavigationController.presentationController?.delegate = coordinate
     rootNavigationController.present(newSubNavigationController, animated: isAnimated)
 


### PR DESCRIPTION
안녕하세요. LinkNavigator 잘 사용하고 있습니다.
sheet 함수에 아래 코드가 두 번 호출되고 있는 것 같아 PR 올려봅니다.

`newSubNavigationController.setViewControllers(new, animated: false)`

혹시 의도된 코드라면 Close 부탁드립니다 :)